### PR TITLE
Don't return a 400 for `/`

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,12 +141,15 @@ func main() {
 
 	prometheus.MustRegister(PrometheusExporter)
 
-	// 400 Bad Request for anything except the configured metrics path, or health if configured.
-	// If you want to make the path obscure to hide it from snooping while still exposing
-	// it to the public web, you don't want to show some "go here instead" message at root etc.
 	if StartParams.Path != "/" {
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`<html>
+    <head><title>Varnish Exporter</title></head>
+    <body>
+        <h1>Varnish Exporter</h1>
+    	<p><a href="` + StartParams.Path + `">Metrics</a></p>
+    </body>
+</html>`))
 		})
 	}
 	if StartParams.HealthPath != "" {


### PR DESCRIPTION
Currently this exporter doesn't behave like other Prometheus exporters, which return a 200 for a `GET HTTP/1.1 /` request. It seems that this was intentional so as to not leak data unintentionally, but I don't personally think that this is a valid reason to deviate from the convention. Specifically, if you don't intend for the Prometheus Varnish exporter to be accessed externally then you should restrict access using security groups, a firewall or `iptables`.

In our use case, we are using `/` as a health check for the exporter itself. This health check is currently failing because the Varnish exporter returns a `400 Bad Request` rather than `200 OK`.