### PR TITLE
Option for only exporting varnish metrics

### DIFF
--- a/extra_key_lables.go
+++ b/extra_key_lables.go
@@ -1,0 +1,32 @@
+package main
+
+type extraLabelValues map[string]string
+
+func (exlv extraLabelValues) getVal(label string) (string, bool) {
+	val, ok := exlv[label]
+	if ok {
+		return val, ok
+	} else {
+		return "", false
+	}
+}
+
+func (exlv extraLabelValues) getLabelValues() map[string]string {
+	return map[string]string(exlv)
+}
+
+func (exlv extraLabelValues) add(key string, val string) bool {
+	oldval, ok := exlv[key]
+	if ok {
+		if oldval == val {
+			return false
+		}
+	}
+	exlv[key] = val
+	return true
+}
+
+func newExtraLabelValues() extraLabelValues {
+	ex := make(map[string]string)
+	return extraLabelValues(ex)
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -43,6 +44,7 @@ type startParams struct {
 	NoExit  bool
 	Test    bool
 	Raw     bool
+	Nogo    bool
 }
 
 type varnishstatParams struct {
@@ -84,6 +86,7 @@ func init() {
 	flag.BoolVar(&StartParams.Verbose, "verbose", StartParams.Verbose, "Verbose logging.")
 	flag.BoolVar(&StartParams.Test, "test", StartParams.Test, "Test varnishstat availability, prints available metrics and exits.")
 	flag.BoolVar(&StartParams.Raw, "raw", StartParams.Test, "Raw stdout logging without timestamps.")
+	flag.BoolVar(&StartParams.Nogo, "no-go-metrics", StartParams.Nogo, "Don't export go runtime and http handler metrics")
 
 	flag.Parse()
 
@@ -158,7 +161,14 @@ func main() {
 	// Start serving
 	logInfo("Server starting on %s with metrics path %s", StartParams.ListenAddress, StartParams.Path)
 
-	prometheus.MustRegister(PrometheusExporter)
+	if StartParams.Nogo {
+		registry := prometheus.NewRegistry()
+		registry.Register(PrometheusExporter)
+		handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+		http.Handle(StartParams.Path, handler)
+	} else {
+		prometheus.MustRegister(PrometheusExporter)
+	}
 
 	if StartParams.Path != "/" {
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -20,15 +20,16 @@ var (
 	VersionHash     string
 	VersionDate     string
 
-	PrometheusExporter = NewPrometheusExporter()
-	VarnishVersion     = NewVarnishVersion()
-	ExitHandler        = &exitHandler{}
+	VarnishVersion = NewVarnishVersion()
+	ExitHandler    = &exitHandler{}
+	exlv           = newExtraLabelValues()
 
 	StartParams = &startParams{
 		ListenAddress:  ":9131", // Reserved and publicly announced at https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 		Path:           "/metrics",
 		VarnishstatExe: "varnishstat",
 		Params:         &varnishstatParams{},
+		Nogo:           true,
 	}
 	logger *log.Logger
 )
@@ -40,11 +41,14 @@ type startParams struct {
 	VarnishstatExe string
 	Params         *varnishstatParams
 
-	Verbose bool
-	NoExit  bool
-	Test    bool
-	Raw     bool
-	Nogo    bool
+	Verbose        bool
+	NoExit         bool
+	Test           bool
+	Raw            bool
+	Nogo           bool
+	VarnishAddress string
+	Environment    string
+	NeedEnv        bool
 }
 
 type varnishstatParams struct {
@@ -87,6 +91,9 @@ func init() {
 	flag.BoolVar(&StartParams.Test, "test", StartParams.Test, "Test varnishstat availability, prints available metrics and exits.")
 	flag.BoolVar(&StartParams.Raw, "raw", StartParams.Test, "Raw stdout logging without timestamps.")
 	flag.BoolVar(&StartParams.Nogo, "no-go-metrics", StartParams.Nogo, "Don't export go runtime and http handler metrics")
+	flag.StringVar(&StartParams.VarnishAddress, "varnish-address", "127.0.0.1", "Ip of the varnish process")
+	flag.StringVar(&StartParams.Environment, "environment", "production", "Environment indicator: stage, dev, production etc.")
+	flag.BoolVar(&StartParams.NeedEnv, "envlabelneeded", false, "Need environment, varnish addressed details label")
 
 	flag.Parse()
 
@@ -114,10 +121,16 @@ func init() {
 }
 
 func main() {
+	var exporter *prometheusExporter
+
 	if b, err := json.MarshalIndent(StartParams, "", "  "); err == nil {
 		logInfo("%s %s %s", ApplicationName, getVersion(false), b)
 	} else {
 		logFatal(err.Error())
+	}
+	if StartParams.NeedEnv {
+		exlv.add("addr", StartParams.VarnishAddress)
+		exlv.add("env", StartParams.Environment)
 	}
 
 	// Initialize
@@ -126,7 +139,8 @@ func main() {
 	}
 	if VarnishVersion.Valid() {
 		logInfo("Found varnishstat %s", VarnishVersion)
-		if err := PrometheusExporter.Initialize(); err != nil {
+		exporter = NewPrometheusExporter()
+		if err := exporter.Initialize(); err != nil {
 			logFatal("Prometheus exporter initialize failed: %s", err.Error())
 		}
 	}
@@ -163,12 +177,12 @@ func main() {
 
 	if StartParams.Nogo {
 		registry := prometheus.NewRegistry()
-		registry.Register(PrometheusExporter)
+		registry.Register(exporter)
 		handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 		//metrics
 		http.Handle(StartParams.Path, handler)
 	} else {
-		prometheus.MustRegister(PrometheusExporter)
+		prometheus.MustRegister(exporter)
 		// metrics
 		http.Handle(StartParams.Path, prometheus.Handler())
 	}

--- a/main.go
+++ b/main.go
@@ -165,9 +165,12 @@ func main() {
 		registry := prometheus.NewRegistry()
 		registry.Register(PrometheusExporter)
 		handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+		//metrics
 		http.Handle(StartParams.Path, handler)
 	} else {
 		prometheus.MustRegister(PrometheusExporter)
+		// metrics
+		http.Handle(StartParams.Path, prometheus.Handler())
 	}
 
 	if StartParams.Path != "/" {
@@ -189,8 +192,6 @@ func main() {
 			fmt.Fprintln(w, "Ok")
 		})
 	}
-	// metrics
-	http.Handle(StartParams.Path, prometheus.Handler())
 	logFatalError(http.ListenAndServe(StartParams.ListenAddress, nil))
 }
 

--- a/prometheus.go
+++ b/prometheus.go
@@ -23,6 +23,17 @@ type prometheusExporter struct {
 }
 
 func NewPrometheusExporter() *prometheusExporter {
+	extralabel_vals := exlv.getLabelValues()
+	if len(extralabel_vals) > 0 {
+		return &prometheusExporter{
+			up: prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace:   exporterNamespace,
+				Name:        "up",
+				Help:        "Was the last scrape of varnish successful.",
+				ConstLabels: extralabel_vals,
+			}),
+		}
+	}
 	return &prometheusExporter{
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: exporterNamespace,
@@ -33,11 +44,18 @@ func NewPrometheusExporter() *prometheusExporter {
 }
 
 func (pe *prometheusExporter) Initialize() error {
+	constl := VarnishVersion.Labels()
+	extralabel_vals := exlv.getLabelValues()
+	if len(extralabel_vals) > 0 {
+		for l, v := range extralabel_vals {
+			constl[l] = v
+		}
+	}
 	pe.version = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:   exporterNamespace,
 		Name:        "version",
 		Help:        "Varnish version information",
-		ConstLabels: VarnishVersion.Labels(),
+		ConstLabels: constl,
 	})
 	pe.version.Set(1)
 	return nil

--- a/varnish.go
+++ b/varnish.go
@@ -124,11 +124,15 @@ func ScrapeVarnishFrom(buf []byte, ch chan<- prometheus.Metric) ([]byte, error) 
 			}
 			continue
 		}
-
 		pName, pDescription, pLabelKeys, pLabelValues := computePrometheusInfo(vName, vGroup, vIdentifier, vDescription)
 
 		descKey := pName + "_" + strings.Join(pLabelKeys, "_")
 		pDesc := DescCache.Desc(descKey)
+		extra_label_vals := exlv.getLabelValues()
+		for l, v := range extra_label_vals {
+			pLabelKeys = append(pLabelKeys, l)
+			pLabelValues = append(pLabelValues, v)
+		}
 		if pDesc == nil {
 			pDesc = DescCache.Set(descKey, prometheus.NewDesc(
 				pName,


### PR DESCRIPTION
Added a command line parameter for  -no-go-metrics to switch on or off exporting go runtime and http handler metrics.