### PR TITLE
fix dir and mac build

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To aggregate all loaded VCLs into per-backend metric the following Prometheus [r
 **Development**
 ```bash
 # clone
-mkdir mkdir -p $GOPATH/src/github.com/jonnenauha
+mkdir -p $GOPATH/src/github.com/jonnenauha
 cd $GOPATH/src/github.com/jonnenauha
 git clone git@github.com:jonnenauha/prometheus_varnish_exporter.git
 cd prometheus_varnish_exporter

--- a/build.sh
+++ b/build.sh
@@ -62,5 +62,5 @@ for goos in linux darwin windows freebsd openbsd netbsd ; do
 done
 
 cd ./bin/release
-sha256sum --binary ./* | sed -En "s/\*\.\/(.*)$/\1/p" > sha256sums.txt
+shasum --algorithm 256 --binary ./* | sed -En "s/\*\.\/(.*)$/\1/p" > sha256sums.txt
 cd ../..


### PR DESCRIPTION
sha256sum did not exist on my mac, nor in brew.  Let me know if the changed sha command works for you still.  Also sorry I don't use github all that often, couldn't figure out how to make these into 2 pull requests