### PR TITLE
Replacing/removing dropped features in PromQL

### DIFF
--- a/dashboards/jonnenauha/dashboard.json
+++ b/dashboards/jonnenauha/dashboard.json
@@ -1186,7 +1186,7 @@
               "step": 60
             },
             {
-              "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[5m]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[5m])) keep_common",
+              "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[5m]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -1197,7 +1197,7 @@
               "step": 60
             },
             {
-              "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[5m]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[5m])) by (backend) keep_common",
+              "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[5m]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[5m])) by (backend)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "backend {{ backend }}",

--- a/dashboards/jonnenauha/dashboard.json
+++ b/dashboards/jonnenauha/dashboard.json
@@ -609,7 +609,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count_scalar(varnish_backend_up{instance=~\"^($varnish_instance).*\"} == 1)",
+              "expr": "scalar(count(varnish_backend_up{instance=~\"^($varnish_instance).*\"} == 1))",
               "format": "time_series",
               "interval": "1m",
               "intervalFactor": 1,
@@ -691,7 +691,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count_scalar(varnish_backend_up{instance=~\"^($varnish_instance).*\"} == 0)",
+              "expr": "scalar(count(varnish_backend_up{instance=~\"^($varnish_instance).*\"} == 0))",
               "format": "time_series",
               "interval": "1m",
               "intervalFactor": 1,


### PR DESCRIPTION
Replaced count_scalar(...) with scalar(count(...)).
Removed keep_common.
This closes #31 .