### PR TITLE
Normalize counter names

### DIFF
--- a/test/scrape/6.0.0.json
+++ b/test/scrape/6.0.0.json
@@ -1514,5 +1514,20 @@
     "description": "Backend requests sent",
     "flag": "c", "format": "i",
     "value": 0
+  },
+  "TEST.#_character": {
+    "description": "Try to trip the parser",
+    "flag": "c", "format": "i",
+    "value": 0
+  },
+  "__TEST.double_underscores": {
+    "description": "Try to trip the parser",
+    "flag": "c", "format": "i",
+    "value": 0
+  },
+  "0TEST.number": {
+    "description": "Try to trip the parser",
+    "flag": "c", "format": "i",
+    "value": 0
   }
 }


### PR DESCRIPTION
New varnish versions allows vmods to create custom counters and it's
mandatory to normalize their names to avoid scaring the scraper.

This commit doesn't prevent collisions but there's only so much we can
do.