### PR TITLE
Varnish 3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/jonnenauha/prometheus_varnish_exporter
 
 go 1.12
 
-require (
-	github.com/prometheus/client_golang v1.0.0
-	github.com/prometheus/common v0.4.1
-)
+require github.com/prometheus/client_golang v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/jonnenauha/prometheus_varnish_exporter
 
 go 1.12
 
-require github.com/prometheus/client_golang v1.0.0
+require (
+	github.com/prometheus/client_golang v1.0.0
+	github.com/prometheus/common v0.4.1
+)

--- a/prometheus.go
+++ b/prometheus.go
@@ -162,13 +162,6 @@ var (
 			total:     "main_n_wrk",
 			desc:      "Number of worker threads",
 		},
-		&grouping{
-			newPrefix: "main_bans",
-			prefix:    "main_n_ban",
-			total:     "main_n_ban",
-			desc:      "Number of bans",
-			labelKey:  "action",
-		},
 	}
 	fqNames = map[string]string{
 		"varnish_lck_colls":   "varnish_lock_collisions",

--- a/test/scrape/3.0.5.json
+++ b/test/scrape/3.0.5.json
@@ -1,0 +1,1214 @@
+{
+    "timestamp": "2019-08-20T00:03:35",
+    "client_conn": {
+        "value": 216,
+        "flag": "a",
+        "description": "Client connections accepted"
+    },
+    "client_drop": {
+        "value": 0,
+        "flag": "a",
+        "description": "Connection dropped, no sess/wrk"
+    },
+    "client_req": {
+        "value": 0,
+        "flag": "a",
+        "description": "Client requests received"
+    },
+    "cache_hit": {
+        "value": 0,
+        "flag": "a",
+        "description": "Cache hits"
+    },
+    "cache_hitpass": {
+        "value": 0,
+        "flag": "a",
+        "description": "Cache hits for pass"
+    },
+    "cache_miss": {
+        "value": 0,
+        "flag": "a",
+        "description": "Cache misses"
+    },
+    "backend_conn": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. success"
+    },
+    "backend_unhealthy": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. not attempted"
+    },
+    "backend_busy": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. too many"
+    },
+    "backend_fail": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. failures"
+    },
+    "backend_reuse": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. reuses"
+    },
+    "backend_toolate": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. was closed"
+    },
+    "backend_recycle": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. recycles"
+    },
+    "backend_retry": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend conn. retry"
+    },
+    "fetch_head": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch head"
+    },
+    "fetch_length": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch with Length"
+    },
+    "fetch_chunked": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch chunked"
+    },
+    "fetch_eof": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch EOF"
+    },
+    "fetch_bad": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch had bad headers"
+    },
+    "fetch_close": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch wanted close"
+    },
+    "fetch_oldhttp": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch pre HTTP/1.1 closed"
+    },
+    "fetch_zero": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch zero len"
+    },
+    "fetch_failed": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch failed"
+    },
+    "fetch_1xx": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch no body (1xx)"
+    },
+    "fetch_204": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch no body (204)"
+    },
+    "fetch_304": {
+        "value": 0,
+        "flag": "a",
+        "description": "Fetch no body (304)"
+    },
+    "n_sess_mem": {
+        "value": 10,
+        "flag": "i",
+        "description": "N struct sess_mem"
+    },
+    "n_sess": {
+        "value": 0,
+        "flag": "i",
+        "description": "N struct sess"
+    },
+    "n_object": {
+        "value": 0,
+        "flag": "i",
+        "description": "N struct object"
+    },
+    "n_vampireobject": {
+        "value": 0,
+        "flag": "i",
+        "description": "N unresurrected objects"
+    },
+    "n_objectcore": {
+        "value": 0,
+        "flag": "i",
+        "description": "N struct objectcore"
+    },
+    "n_objecthead": {
+        "value": 0,
+        "flag": "i",
+        "description": "N struct objecthead"
+    },
+    "n_waitinglist": {
+        "value": 0,
+        "flag": "i",
+        "description": "N struct waitinglist"
+    },
+    "n_vbc": {
+        "value": 0,
+        "flag": "i",
+        "description": "N struct vbc"
+    },
+    "n_wrk": {
+        "value": 10,
+        "flag": "i",
+        "description": "N worker threads"
+    },
+    "n_wrk_create": {
+        "value": 10,
+        "flag": "a",
+        "description": "N worker threads created"
+    },
+    "n_wrk_failed": {
+        "value": 0,
+        "flag": "a",
+        "description": "N worker threads not created"
+    },
+    "n_wrk_max": {
+        "value": 0,
+        "flag": "a",
+        "description": "N worker threads limited"
+    },
+    "n_wrk_lqueue": {
+        "value": 0,
+        "flag": "a",
+        "description": "work request queue length"
+    },
+    "n_wrk_queued": {
+        "value": 0,
+        "flag": "a",
+        "description": "N queued work requests"
+    },
+    "n_wrk_drop": {
+        "value": 0,
+        "flag": "a",
+        "description": "N dropped work requests"
+    },
+    "n_backend": {
+        "value": 1,
+        "flag": "i",
+        "description": "N backends"
+    },
+    "n_expired": {
+        "value": 0,
+        "flag": "i",
+        "description": "N expired objects"
+    },
+    "n_lru_nuked": {
+        "value": 0,
+        "flag": "i",
+        "description": "N LRU nuked objects"
+    },
+    "n_lru_moved": {
+        "value": 0,
+        "flag": "i",
+        "description": "N LRU moved objects"
+    },
+    "losthdr": {
+        "value": 0,
+        "flag": "a",
+        "description": "HTTP header overflows"
+    },
+    "n_objsendfile": {
+        "value": 0,
+        "flag": "a",
+        "description": "Objects sent with sendfile"
+    },
+    "n_objwrite": {
+        "value": 0,
+        "flag": "a",
+        "description": "Objects sent with write"
+    },
+    "n_objoverflow": {
+        "value": 0,
+        "flag": "a",
+        "description": "Objects overflowing workspace"
+    },
+    "s_sess": {
+        "value": 216,
+        "flag": "a",
+        "description": "Total Sessions"
+    },
+    "s_req": {
+        "value": 0,
+        "flag": "a",
+        "description": "Total Requests"
+    },
+    "s_pipe": {
+        "value": 0,
+        "flag": "a",
+        "description": "Total pipe"
+    },
+    "s_pass": {
+        "value": 0,
+        "flag": "a",
+        "description": "Total pass"
+    },
+    "s_fetch": {
+        "value": 0,
+        "flag": "a",
+        "description": "Total fetch"
+    },
+    "s_hdrbytes": {
+        "value": 0,
+        "flag": "a",
+        "description": "Total header bytes"
+    },
+    "s_bodybytes": {
+        "value": 0,
+        "flag": "a",
+        "description": "Total body bytes"
+    },
+    "sess_closed": {
+        "value": 216,
+        "flag": "a",
+        "description": "Session Closed"
+    },
+    "sess_pipeline": {
+        "value": 0,
+        "flag": "a",
+        "description": "Session Pipeline"
+    },
+    "sess_readahead": {
+        "value": 0,
+        "flag": "a",
+        "description": "Session Read Ahead"
+    },
+    "sess_linger": {
+        "value": 0,
+        "flag": "a",
+        "description": "Session Linger"
+    },
+    "sess_herd": {
+        "value": 0,
+        "flag": "a",
+        "description": "Session herd"
+    },
+    "shm_records": {
+        "value": 673,
+        "flag": "a",
+        "description": "SHM records"
+    },
+    "shm_writes": {
+        "value": 673,
+        "flag": "a",
+        "description": "SHM writes"
+    },
+    "shm_flushes": {
+        "value": 0,
+        "flag": "a",
+        "description": "SHM flushes due to overflow"
+    },
+    "shm_cont": {
+        "value": 0,
+        "flag": "a",
+        "description": "SHM MTX contention"
+    },
+    "shm_cycles": {
+        "value": 0,
+        "flag": "a",
+        "description": "SHM cycles through buffer"
+    },
+    "sms_nreq": {
+        "value": 0,
+        "flag": "a",
+        "description": "SMS allocator requests"
+    },
+    "sms_nobj": {
+        "value": 0,
+        "flag": "i",
+        "description": "SMS outstanding allocations"
+    },
+    "sms_nbytes": {
+        "value": 0,
+        "flag": "i",
+        "description": "SMS outstanding bytes"
+    },
+    "sms_balloc": {
+        "value": 0,
+        "flag": "i",
+        "description": "SMS bytes allocated"
+    },
+    "sms_bfree": {
+        "value": 0,
+        "flag": "i",
+        "description": "SMS bytes freed"
+    },
+    "backend_req": {
+        "value": 0,
+        "flag": "a",
+        "description": "Backend requests made"
+    },
+    "n_vcl": {
+        "value": 1,
+        "flag": "a",
+        "description": "N vcl total"
+    },
+    "n_vcl_avail": {
+        "value": 1,
+        "flag": "a",
+        "description": "N vcl available"
+    },
+    "n_vcl_discard": {
+        "value": 0,
+        "flag": "a",
+        "description": "N vcl discarded"
+    },
+    "n_ban": {
+        "value": 1,
+        "flag": "i",
+        "description": "N total active bans"
+    },
+    "n_ban_gone": {
+        "value": 1,
+        "flag": "i",
+        "description": "N total gone bans"
+    },
+    "n_ban_add": {
+        "value": 1,
+        "flag": "a",
+        "description": "N new bans added"
+    },
+    "n_ban_retire": {
+        "value": 0,
+        "flag": "a",
+        "description": "N old bans deleted"
+    },
+    "n_ban_obj_test": {
+        "value": 0,
+        "flag": "a",
+        "description": "N objects tested"
+    },
+    "n_ban_re_test": {
+        "value": 0,
+        "flag": "a",
+        "description": "N regexps tested against"
+    },
+    "n_ban_dups": {
+        "value": 0,
+        "flag": "a",
+        "description": "N duplicate bans removed"
+    },
+    "hcb_nolock": {
+        "value": 0,
+        "flag": "a",
+        "description": "HCB Lookups without lock"
+    },
+    "hcb_lock": {
+        "value": 0,
+        "flag": "a",
+        "description": "HCB Lookups with lock"
+    },
+    "hcb_insert": {
+        "value": 0,
+        "flag": "a",
+        "description": "HCB Inserts"
+    },
+    "esi_errors": {
+        "value": 0,
+        "flag": "a",
+        "description": "ESI parse errors (unlock)"
+    },
+    "esi_warnings": {
+        "value": 0,
+        "flag": "a",
+        "description": "ESI parse warnings (unlock)"
+    },
+    "accept_fail": {
+        "value": 0,
+        "flag": "a",
+        "description": "Accept failures"
+    },
+    "client_drop_late": {
+        "value": 0,
+        "flag": "a",
+        "description": "Connection dropped late"
+    },
+    "uptime": {
+        "value": 561,
+        "flag": "a",
+        "description": "Client uptime"
+    },
+    "dir_dns_lookups": {
+        "value": 0,
+        "flag": "a",
+        "description": "DNS director lookups"
+    },
+    "dir_dns_failed": {
+        "value": 0,
+        "flag": "a",
+        "description": "DNS director failed lookups"
+    },
+    "dir_dns_hit": {
+        "value": 0,
+        "flag": "a",
+        "description": "DNS director cached lookups hit"
+    },
+    "dir_dns_cache_full": {
+        "value": 0,
+        "flag": "a",
+        "description": "DNS director full dnscache"
+    },
+    "vmods": {
+        "value": 0,
+        "flag": "i",
+        "description": "Loaded VMODs"
+    },
+    "n_gzip": {
+        "value": 0,
+        "flag": "a",
+        "description": "Gzip operations"
+    },
+    "n_gunzip": {
+        "value": 0,
+        "flag": "a",
+        "description": "Gunzip operations"
+    },
+    "sess_pipe_overflow": {
+        "value": 0,
+        "flag": "c",
+        "description": "Dropped sessions due to session pipe overflow"
+    },
+    "LCK.sms.creat": {
+        "type": "LCK",
+        "ident": "sms",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.sms.destroy": {
+        "type": "LCK",
+        "ident": "sms",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.sms.locks": {
+        "type": "LCK",
+        "ident": "sms",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.sms.colls": {
+        "type": "LCK",
+        "ident": "sms",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.smp.creat": {
+        "type": "LCK",
+        "ident": "smp",
+        "value": 0,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.smp.destroy": {
+        "type": "LCK",
+        "ident": "smp",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.smp.locks": {
+        "type": "LCK",
+        "ident": "smp",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.smp.colls": {
+        "type": "LCK",
+        "ident": "smp",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.sma.creat": {
+        "type": "LCK",
+        "ident": "sma",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.sma.destroy": {
+        "type": "LCK",
+        "ident": "sma",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.sma.locks": {
+        "type": "LCK",
+        "ident": "sma",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.sma.colls": {
+        "type": "LCK",
+        "ident": "sma",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.smf.creat": {
+        "type": "LCK",
+        "ident": "smf",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.smf.destroy": {
+        "type": "LCK",
+        "ident": "smf",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.smf.locks": {
+        "type": "LCK",
+        "ident": "smf",
+        "value": 1,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.smf.colls": {
+        "type": "LCK",
+        "ident": "smf",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.hsl.creat": {
+        "type": "LCK",
+        "ident": "hsl",
+        "value": 0,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.hsl.destroy": {
+        "type": "LCK",
+        "ident": "hsl",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.hsl.locks": {
+        "type": "LCK",
+        "ident": "hsl",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.hsl.colls": {
+        "type": "LCK",
+        "ident": "hsl",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.hcb.creat": {
+        "type": "LCK",
+        "ident": "hcb",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.hcb.destroy": {
+        "type": "LCK",
+        "ident": "hcb",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.hcb.locks": {
+        "type": "LCK",
+        "ident": "hcb",
+        "value": 4,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.hcb.colls": {
+        "type": "LCK",
+        "ident": "hcb",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.hcl.creat": {
+        "type": "LCK",
+        "ident": "hcl",
+        "value": 0,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.hcl.destroy": {
+        "type": "LCK",
+        "ident": "hcl",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.hcl.locks": {
+        "type": "LCK",
+        "ident": "hcl",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.hcl.colls": {
+        "type": "LCK",
+        "ident": "hcl",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.vcl.creat": {
+        "type": "LCK",
+        "ident": "vcl",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.vcl.destroy": {
+        "type": "LCK",
+        "ident": "vcl",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.vcl.locks": {
+        "type": "LCK",
+        "ident": "vcl",
+        "value": 5,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.vcl.colls": {
+        "type": "LCK",
+        "ident": "vcl",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.stat.creat": {
+        "type": "LCK",
+        "ident": "stat",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.stat.destroy": {
+        "type": "LCK",
+        "ident": "stat",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.stat.locks": {
+        "type": "LCK",
+        "ident": "stat",
+        "value": 226,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.stat.colls": {
+        "type": "LCK",
+        "ident": "stat",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.sessmem.creat": {
+        "type": "LCK",
+        "ident": "sessmem",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.sessmem.destroy": {
+        "type": "LCK",
+        "ident": "sessmem",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.sessmem.locks": {
+        "type": "LCK",
+        "ident": "sessmem",
+        "value": 253,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.sessmem.colls": {
+        "type": "LCK",
+        "ident": "sessmem",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.wstat.creat": {
+        "type": "LCK",
+        "ident": "wstat",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.wstat.destroy": {
+        "type": "LCK",
+        "ident": "wstat",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.wstat.locks": {
+        "type": "LCK",
+        "ident": "wstat",
+        "value": 1129,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.wstat.colls": {
+        "type": "LCK",
+        "ident": "wstat",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.herder.creat": {
+        "type": "LCK",
+        "ident": "herder",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.herder.destroy": {
+        "type": "LCK",
+        "ident": "herder",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.herder.locks": {
+        "type": "LCK",
+        "ident": "herder",
+        "value": 1,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.herder.colls": {
+        "type": "LCK",
+        "ident": "herder",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.wq.creat": {
+        "type": "LCK",
+        "ident": "wq",
+        "value": 2,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.wq.destroy": {
+        "type": "LCK",
+        "ident": "wq",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.wq.locks": {
+        "type": "LCK",
+        "ident": "wq",
+        "value": 1566,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.wq.colls": {
+        "type": "LCK",
+        "ident": "wq",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.objhdr.creat": {
+        "type": "LCK",
+        "ident": "objhdr",
+        "value": 0,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.objhdr.destroy": {
+        "type": "LCK",
+        "ident": "objhdr",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.objhdr.locks": {
+        "type": "LCK",
+        "ident": "objhdr",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.objhdr.colls": {
+        "type": "LCK",
+        "ident": "objhdr",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.exp.creat": {
+        "type": "LCK",
+        "ident": "exp",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.exp.destroy": {
+        "type": "LCK",
+        "ident": "exp",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.exp.locks": {
+        "type": "LCK",
+        "ident": "exp",
+        "value": 561,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.exp.colls": {
+        "type": "LCK",
+        "ident": "exp",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.lru.creat": {
+        "type": "LCK",
+        "ident": "lru",
+        "value": 2,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.lru.destroy": {
+        "type": "LCK",
+        "ident": "lru",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.lru.locks": {
+        "type": "LCK",
+        "ident": "lru",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.lru.colls": {
+        "type": "LCK",
+        "ident": "lru",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.cli.creat": {
+        "type": "LCK",
+        "ident": "cli",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.cli.destroy": {
+        "type": "LCK",
+        "ident": "cli",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.cli.locks": {
+        "type": "LCK",
+        "ident": "cli",
+        "value": 18,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.cli.colls": {
+        "type": "LCK",
+        "ident": "cli",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.ban.creat": {
+        "type": "LCK",
+        "ident": "ban",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.ban.destroy": {
+        "type": "LCK",
+        "ident": "ban",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.ban.locks": {
+        "type": "LCK",
+        "ident": "ban",
+        "value": 564,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.ban.colls": {
+        "type": "LCK",
+        "ident": "ban",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.vbp.creat": {
+        "type": "LCK",
+        "ident": "vbp",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.vbp.destroy": {
+        "type": "LCK",
+        "ident": "vbp",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.vbp.locks": {
+        "type": "LCK",
+        "ident": "vbp",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.vbp.colls": {
+        "type": "LCK",
+        "ident": "vbp",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.vbe.creat": {
+        "type": "LCK",
+        "ident": "vbe",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.vbe.destroy": {
+        "type": "LCK",
+        "ident": "vbe",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.vbe.locks": {
+        "type": "LCK",
+        "ident": "vbe",
+        "value": 0,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.vbe.colls": {
+        "type": "LCK",
+        "ident": "vbe",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "LCK.backend.creat": {
+        "type": "LCK",
+        "ident": "backend",
+        "value": 1,
+        "flag": "a",
+        "description": "Created locks"
+    },
+    "LCK.backend.destroy": {
+        "type": "LCK",
+        "ident": "backend",
+        "value": 0,
+        "flag": "a",
+        "description": "Destroyed locks"
+    },
+    "LCK.backend.locks": {
+        "type": "LCK",
+        "ident": "backend",
+        "value": 1,
+        "flag": "a",
+        "description": "Lock Operations"
+    },
+    "LCK.backend.colls": {
+        "type": "LCK",
+        "ident": "backend",
+        "value": 0,
+        "flag": "a",
+        "description": "Collisions"
+    },
+    "SMF.s0.c_req": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 0,
+        "flag": "a",
+        "description": "Allocator requests"
+    },
+    "SMF.s0.c_fail": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 0,
+        "flag": "a",
+        "description": "Allocator failures"
+    },
+    "SMF.s0.c_bytes": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 0,
+        "flag": "a",
+        "description": "Bytes allocated"
+    },
+    "SMF.s0.c_freed": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 0,
+        "flag": "a",
+        "description": "Bytes freed"
+    },
+    "SMF.s0.g_alloc": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 0,
+        "flag": "i",
+        "description": "Allocations outstanding"
+    },
+    "SMF.s0.g_bytes": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 0,
+        "flag": "i",
+        "description": "Bytes outstanding"
+    },
+    "SMF.s0.g_space": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 2220228608,
+        "flag": "i",
+        "description": "Bytes available"
+    },
+    "SMF.s0.g_smf": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 4,
+        "flag": "i",
+        "description": "N struct smf"
+    },
+    "SMF.s0.g_smf_frag": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 0,
+        "flag": "i",
+        "description": "N small free smf"
+    },
+    "SMF.s0.g_smf_large": {
+        "type": "SMF",
+        "ident": "s0",
+        "value": 4,
+        "flag": "i",
+        "description": "N large free smf"
+    },
+    "SMA.Transient.c_req": {
+        "type": "SMA",
+        "ident": "Transient",
+        "value": 0,
+        "flag": "a",
+        "description": "Allocator requests"
+    },
+    "SMA.Transient.c_fail": {
+        "type": "SMA",
+        "ident": "Transient",
+        "value": 0,
+        "flag": "a",
+        "description": "Allocator failures"
+    },
+    "SMA.Transient.c_bytes": {
+        "type": "SMA",
+        "ident": "Transient",
+        "value": 0,
+        "flag": "a",
+        "description": "Bytes allocated"
+    },
+    "SMA.Transient.c_freed": {
+        "type": "SMA",
+        "ident": "Transient",
+        "value": 0,
+        "flag": "a",
+        "description": "Bytes freed"
+    },
+    "SMA.Transient.g_alloc": {
+        "type": "SMA",
+        "ident": "Transient",
+        "value": 0,
+        "flag": "i",
+        "description": "Allocations outstanding"
+    },
+    "SMA.Transient.g_bytes": {
+        "type": "SMA",
+        "ident": "Transient",
+        "value": 0,
+        "flag": "i",
+        "description": "Bytes outstanding"
+    },
+    "SMA.Transient.g_space": {
+        "type": "SMA",
+        "ident": "Transient",
+        "value": 0,
+        "flag": "i",
+        "description": "Bytes available"
+    },
+    "VBE.default(10.100.225.15,,80).vcls": {
+        "type": "VBE",
+        "ident": "default(10.100.225.15,,80)",
+        "value": 1,
+        "flag": "i",
+        "description": "VCL references"
+    },
+    "VBE.default(10.100.225.15,,80).happy": {
+        "type": "VBE",
+        "ident": "default(10.100.225.15,,80)",
+        "value": 0,
+        "flag": "b",
+        "description": "Happy health probes"
+    }
+}

--- a/varnish_test.go
+++ b/varnish_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var testFileVersions = []string{"4.0.5", "4.1.1", "5.2.0", "6.0.0"}
+var testFileVersions = []string{"3.0.5", "4.0.5", "4.1.1", "5.2.0", "6.0.0"}
 
 func Test_VarnishVersion(t *testing.T) {
 	tests := map[string]*varnishVersion{

--- a/varnish_test.go
+++ b/varnish_test.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+var testFileVersions = []string{"4.0.5", "4.1.1", "5.2.0", "6.0.0"}
 
 func Test_VarnishVersion(t *testing.T) {
 	tests := map[string]*varnishVersion{
@@ -144,13 +145,8 @@ func Test_VarnishMetrics(t *testing.T) {
 	if !fileExists(filepath.Join(dir, "test/scrape")) {
 		t.Skipf("Cannot find test/scrape files from workind dir %s", dir)
 	}
-	for _, test := range []string{
-		filepath.Join(dir, "test/scrape", "4.0.5.json"),
-		filepath.Join(dir, "test/scrape", "4.1.1.json"),
-		filepath.Join(dir, "test/scrape", "5.2.0.json"),
-		filepath.Join(dir, "test/scrape", "6.0.0.json"),
-	} {
-		version := strings.Replace(filepath.Base(test), ".json", "", -1)
+	for _, version := range testFileVersions {
+		test := filepath.Join(dir, "test/scrape", version+".json")
 		VarnishVersion.parseVersion(version)
 		t.Logf("test scrape %s", VarnishVersion)
 
@@ -175,6 +171,62 @@ func Test_VarnishMetrics(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 		t.Logf("  %d metrics", len(descs))
+	}
+}
+
+type testCollector struct {
+	filepath string
+	t        *testing.T
+}
+
+func (tc *testCollector) Describe(ch chan<- *prometheus.Desc) {
+}
+
+func (tc *testCollector) Collect(ch chan<- prometheus.Metric) {
+	buf, err := ioutil.ReadFile(tc.filepath)
+	if err != nil {
+		tc.t.Fatal(err.Error())
+	}
+	_, err = ScrapeVarnishFrom(buf, ch)
+
+	if err != nil {
+		tc.t.Fatal(err.Error())
+	}
+}
+
+func Test_PrometheusExport(t *testing.T) {
+	dir, _ := os.Getwd()
+	if !fileExists(filepath.Join(dir, "test/scrape")) {
+		t.Skipf("Cannot find test/scrape files from workind dir %s", dir)
+	}
+	for _, version := range testFileVersions {
+		test := filepath.Join(dir, "test/scrape", version+".json")
+		VarnishVersion.parseVersion(version)
+		t.Logf("test scrape %s", VarnishVersion)
+
+		registry := prometheus.NewRegistry()
+		collector := &testCollector{filepath: test}
+		registry.MustRegister(collector)
+
+		gathering, err := registry.Gather()
+		if err != nil {
+			errors, ok := err.(prometheus.MultiError)
+			if ok {
+				for _, e := range errors {
+					t.Errorf("  Error in prometheus Gather: %#v", e)
+				}
+			} else {
+				t.Errorf("  Error in prometheus Gather: %#v", err)
+			}
+		}
+
+		metricCount := 0
+
+		for _, mf := range gathering {
+			metricCount += len(mf.Metric)
+		}
+
+		t.Logf("  %d metrics", metricCount)
 	}
 }
 


### PR DESCRIPTION
Fixes an error when scraping metrics from Varnish 3:
```
varnish_main_bans label:<name:\"action\" value:\"gone\" > gauge:<value:1 > should be a Counter
```

Also adds a Prometheus gather test which replicates that error.

Resolves #50 