### PR TITLE
Clean backend name if beginning with reload_

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -230,6 +230,16 @@ func cleanBackendName(name string) string {
 			name = name[len(prefix):]
 		}
 	}
+
+	// reload_2019-08-29T100458.<name> as by varnish_reload_vcl in 4.x
+	// reload_20191014_091124_78599.<name> as by varnishreload in 6+
+	if strings.HasPrefix(name, "reload_") {
+		dot := strings.Index(name, ".")
+		if dot != -1 {
+			name = name[dot + 1:]
+		}
+	}
+
 	return name
 }
 

--- a/varnish_test.go
+++ b/varnish_test.go
@@ -95,6 +95,8 @@ func Test_VarnishBackendNames(t *testing.T) {
 		{"def0e7f7-a676-4eed-9d8b-78ef7ce21e93.us1_x.y-z:w", "us1_x.y-z:w", "def0e7f7-a676-4eed-9d8b-78ef7ce21e93"},
 		{"root:29813cbb-7329-4eb8-8969-26be2ef58c88.us2_x.y-z:w", "us2_x.y-z:w", "29813cbb-7329-4eb8-8969-26be2ef58c88"}, // ??
 		{"boot.default", "default", "unknown"},
+		{"reload_2019-08-29T100458.default", "default", "unknown"}, // varnish_reload_vcl in 4
+		{"reload_20191016_072034_54500.default", "default", "unknown"}, // varnishreload in 6+
 		{"ce19737f-72b5-4f4b-9d39-3d8c2d28240b.default", "default", "ce19737f-72b5-4f4b-9d39-3d8c2d28240b"},
 	} {
 		backend := variant[0]


### PR DESCRIPTION
When using often-shipped scripts to reload varnish VCLs, the backend names changes from "boot" to reload_xxxxx.

Initially, metrics would be exported with `default`, then after one reload it would be `reload_20191016_072034_54500.default`.

The varnish_reload_vcl script as shipped with Varnish 4 packages uses one format,
and varnishreload shipped with 6+ packages uses a slightly different.
This covers both.


Note: this is my very first attempt on Go coding, so feel free to point out improvements!