### PR TITLE
Calculate hitrate the same way varnishstat does it

### DIFF
--- a/dashboards/jonnenauha/dashboard.json
+++ b/dashboards/jonnenauha/dashboard.json
@@ -114,6 +114,7 @@
           "targets": [
             {
               "expr": "avg(( rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[5m]) ))",
+              "expr": "avg(( rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) / ( rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) + rate(varnish_main_cache_miss{instance=~\"^($varnish_instance).*\"}[5m]) ) ))",
               "format": "time_series",
               "hide": false,
               "interval": "",

--- a/dashboards/jonnenauha/dashboard.json
+++ b/dashboards/jonnenauha/dashboard.json
@@ -113,7 +113,6 @@
           "tableColumn": "Value",
           "targets": [
             {
-              "expr": "avg(( rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[5m]) ))",
               "expr": "avg(( rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) / ( rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) + rate(varnish_main_cache_miss{instance=~\"^($varnish_instance).*\"}[5m]) ) ))",
               "format": "time_series",
               "hide": false,


### PR DESCRIPTION
Using the client request rate for hitrate calculation is not accurate because there are things like ESI that increase hits without increasing client requests. This is how varnishstat does it: https://github.com/varnishcache/varnish-cache/blob/9b5332e2a2e0c5d3a0485704164ea9d3cebe4b68/bin/varnishstat/varnishstat_curses.c#L300