### PR TITLE
[NFG] Fix for newer Varnish versions

### DIFF
--- a/varnish.go
+++ b/varnish.go
@@ -67,8 +67,15 @@ func ScrapeVarnishFrom(buf []byte, ch chan<- prometheus.Metric) ([]byte, error) 
 		return buf, err
 	}
 
-	for vName, raw := range metricsJSON {
-		if vName == "timestamp" {
+	countersJSON := make(map[string]interface{})
+	if metricsJSON["version"] == 1 {
+		countersJSON = metricsJSON["counters"]
+	} else {
+		countersJSON = metricsJSON
+	}
+
+	for vName, raw := range countersJSON {
+		if vName == "version" || vName == "timestamp" {
 			continue
 		}
 		if dt := reflect.TypeOf(raw); dt.Kind() != reflect.Map {


### PR DESCRIPTION
Varnishstat's JSON output now has a `counters` object that contains all the metrics (and a `version` field to indicate this).
Unfortunately my GoFu is not that good to quickly fix it, but maybe i'll figure it out later.

I guess you should be able to get this to compile in no time. ;-)

```
{
  "version": 1,
  "timestamp": "2020-09-22T11:55:40",
  "counters": {
    "MGT.uptime": {
      "description": "Management process uptime",
      "flag": "c",
      "format": "d",
      "value": 4725
    },
    ...
```