### PR TITLE
Fix issue 57 - errors on VCL reload because of duplicated counters

### DIFF
--- a/test/scrape/6.5.1.json
+++ b/test/scrape/6.5.1.json
@@ -1952,6 +1952,246 @@
       "format": "i",
       "value": 0
     },
+    "VBE.reload_20210114_155148_19902.default.happy": {
+      "description": "Happy health probes",
+      "flag": "b",
+      "format": "b",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.bereq_hdrbytes": {
+      "description": "Request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 6901
+    },
+    "VBE.reload_20210114_155148_19902.default.bereq_bodybytes": {
+      "description": "Request body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.beresp_hdrbytes": {
+      "description": "Response header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 5637
+    },
+    "VBE.reload_20210114_155148_19902.default.beresp_bodybytes": {
+      "description": "Response body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 44
+    },
+    "VBE.reload_20210114_155148_19902.default.pipe_hdrbytes": {
+      "description": "Pipe request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.pipe_out": {
+      "description": "Piped bytes to backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.pipe_in": {
+      "description": "Piped bytes from backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.conn": {
+      "description": "Concurrent connections used",
+      "flag": "g",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.req": {
+      "description": "Backend requests sent",
+      "flag": "c",
+      "format": "i",
+      "value": 27
+    },
+    "VBE.reload_20210114_155148_19902.default.unhealthy": {
+      "description": "Fetches not attempted due to backend being unhealthy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.busy": {
+      "description": "Fetches not attempted due to backend being busy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail": {
+      "description": "Connections failed",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_eacces": {
+      "description": "Connections failed with EACCES or EPERM",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_eaddrnotavail": {
+      "description": "Connections failed with EADDRNOTAVAIL",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_econnrefused": {
+      "description": "Connections failed with ECONNREFUSED",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_enetunreach": {
+      "description": "Connections failed with ENETUNREACH",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_etimedout": {
+      "description": "Connections failed ETIMEDOUT",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_other": {
+      "description": "Connections failed for other reason",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.helddown": {
+      "description": "Connection opens not attempted",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.happy": {
+      "description": "Happy health probes",
+      "flag": "b",
+      "format": "b",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.bereq_hdrbytes": {
+      "description": "Request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 6901
+    },
+    "VBE.reload_20210114_160902_21476.default.bereq_bodybytes": {
+      "description": "Request body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.beresp_hdrbytes": {
+      "description": "Response header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 5637
+    },
+    "VBE.reload_20210114_160902_21476.default.beresp_bodybytes": {
+      "description": "Response body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 44
+    },
+    "VBE.reload_20210114_160902_21476.default.pipe_hdrbytes": {
+      "description": "Pipe request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.pipe_out": {
+      "description": "Piped bytes to backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.pipe_in": {
+      "description": "Piped bytes from backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.conn": {
+      "description": "Concurrent connections used",
+      "flag": "g",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.req": {
+      "description": "Backend requests sent",
+      "flag": "c",
+      "format": "i",
+      "value": 27
+    },
+    "VBE.reload_20210114_160902_21476.default.unhealthy": {
+      "description": "Fetches not attempted due to backend being unhealthy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.busy": {
+      "description": "Fetches not attempted due to backend being busy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail": {
+      "description": "Connections failed",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_eacces": {
+      "description": "Connections failed with EACCES or EPERM",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_eaddrnotavail": {
+      "description": "Connections failed with EADDRNOTAVAIL",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_econnrefused": {
+      "description": "Connections failed with ECONNREFUSED",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_enetunreach": {
+      "description": "Connections failed with ENETUNREACH",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_etimedout": {
+      "description": "Connections failed ETIMEDOUT",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_other": {
+      "description": "Connections failed for other reason",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.helddown": {
+      "description": "Connection opens not attempted",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
     "VBE.boot.default.helddown": {
       "description": "Connection opens not attempted",
       "flag": "c",

--- a/varnish_test.go
+++ b/varnish_test.go
@@ -192,6 +192,71 @@ func Test_VarnishMetrics(t *testing.T) {
 	}
 }
 
+func Test_FindMostRecentVbeReloadPrefix(t *testing.T) {
+	type testConfig struct {
+		varnishCounters                   map[string]interface{}
+		expectedMostRecentVbeReloadPrefix string
+	}
+
+	for _, testConfig := range []testConfig{
+		// Varnish <= 4.0 has no duplicated stats on reload
+		{map[string]interface{}{
+			"VBE.default(127.0.0.1,,8080).happy": "any",
+		}, ""},
+		// Varnish 4.1 or later, not yet reloaded
+		{map[string]interface{}{
+			"VBE.boot.default.happy": "any",
+		}, ""},
+		// Varnish 4.1, reloaded 2 times
+		{map[string]interface{}{
+			"VBE.boot.default.happy":                     "any",
+			"VBE.reload_2019-08-29T100458.default.happy": "any",
+			"VBE.reload_2019-08-29T100459.default.happy": "any",
+		}, "VBE.reload_2019-08-29T100459"},
+		// Varnish 6+, reloaded 2 times
+		{map[string]interface{}{
+			"VBE.boot.default.happy":                         "any",
+			"VBE.reload_20191016_072034_54500.default.happy": "any",
+			"VBE.reload_20191016_072034_54501.default.happy": "any",
+		}, "VBE.reload_20191016_072034_54501"},
+	} {
+		computedMostRecentVbeReloadPrefix := findMostRecentVbeReloadPrefix(testConfig.varnishCounters)
+		t.Logf("Varnish counters: %s\n", testConfig.varnishCounters)
+		t.Logf("  expected most recent prefix : '%s'\n", testConfig.expectedMostRecentVbeReloadPrefix)
+		t.Logf("  computed most recent prefix : '%s'\n", computedMostRecentVbeReloadPrefix)
+
+		if computedMostRecentVbeReloadPrefix != testConfig.expectedMostRecentVbeReloadPrefix {
+			t.Fatalf("mostRecentVbeReloadPrefix %q != %q", computedMostRecentVbeReloadPrefix, testConfig.expectedMostRecentVbeReloadPrefix)
+		}
+	}
+}
+
+func Test_IsOutdatedVbe(t *testing.T) {
+	type testConfig struct {
+		vName                     string
+		mostRecentVbeReloadPrefix string
+		expecteedIsOutdatedVbe    bool
+	}
+
+	for _, testConfig := range []testConfig{
+		{"MGT.uptime", "", false},                                                                    // not VBE
+		{"MGT.uptime", "VBE.reload_20191016_072034_54500", false},                                    // not VBE
+		{"VBE.boot.default.conn", "", false},                                                         // VCL not yet reloaded
+		{"VBE.boot.default.conn", "VBE.reload_20191016_072034_54500", true},                          // VCL reloaded, 'boot' is now outdated
+		{"VBE.reload_20191016_072034_54500.default.conn", "VBE.reload_20191016_072034_54500", false}, // current VCL version
+		{"VBE.reload_20191016_072034_54499.default.conn", "VBE.reload_20191016_072034_54500", true},  // previous VCL version
+	} {
+		computedIsOutdatedVbe := isOutdatedVbe(testConfig.vName, testConfig.mostRecentVbeReloadPrefix)
+		t.Logf("'%s', '%s'\n", testConfig.vName, testConfig.mostRecentVbeReloadPrefix)
+		t.Logf("  expected outdated : %t\n", testConfig.expecteedIsOutdatedVbe)
+		t.Logf("  computed outdated : %t\n", computedIsOutdatedVbe)
+
+		if computedIsOutdatedVbe != testConfig.expecteedIsOutdatedVbe {
+			t.Fatalf("outdatedVbe %t != %t", computedIsOutdatedVbe, testConfig.expecteedIsOutdatedVbe)
+		}
+	}
+}
+
 type testCollector struct {
 	filepath string
 	t        *testing.T

--- a/varnish_test.go
+++ b/varnish_test.go
@@ -235,7 +235,7 @@ func Test_IsOutdatedVbe(t *testing.T) {
 	type testConfig struct {
 		vName                     string
 		mostRecentVbeReloadPrefix string
-		expecteedIsOutdatedVbe    bool
+		expectedIsOutdatedVbe     bool
 	}
 
 	for _, testConfig := range []testConfig{
@@ -248,11 +248,11 @@ func Test_IsOutdatedVbe(t *testing.T) {
 	} {
 		computedIsOutdatedVbe := isOutdatedVbe(testConfig.vName, testConfig.mostRecentVbeReloadPrefix)
 		t.Logf("'%s', '%s'\n", testConfig.vName, testConfig.mostRecentVbeReloadPrefix)
-		t.Logf("  expected outdated : %t\n", testConfig.expecteedIsOutdatedVbe)
+		t.Logf("  expected outdated : %t\n", testConfig.expectedIsOutdatedVbe)
 		t.Logf("  computed outdated : %t\n", computedIsOutdatedVbe)
 
-		if computedIsOutdatedVbe != testConfig.expecteedIsOutdatedVbe {
-			t.Fatalf("outdatedVbe %t != %t", computedIsOutdatedVbe, testConfig.expecteedIsOutdatedVbe)
+		if computedIsOutdatedVbe != testConfig.expectedIsOutdatedVbe {
+			t.Fatalf("outdatedVbe %t != %t", computedIsOutdatedVbe, testConfig.expectedIsOutdatedVbe)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #57 

**Issue**
The exporter fails when VCL is reloaded.
This happens because Varnish backend counters (VBE) are repeated for each reload with its timestamp:
Example: `VBE.boot.default.happy` and `VBE.reload_20210114_155148_19902.default.happy`
... thus generating duplicated metrics.

The `-p vcl_cooldown=1`  workaround is not good enough, because old counters are still present in varnishstat for some time (granularity is 30s, see https://varnish-cache.org/docs/6.5/reference/varnishd.html#vcl-cooldown).

The result is that on each reload the exporter keeps failing for some time (1m in my tests with `-p vcl_cooldown=1`, 10m without it).

**Solution**
I propose to consider only the counters with the most recent timestamp.
I quickly calculate the most recent timestamp by checking the ".happy" counters, then I filter out the outdated counters.
Should work for any Varnish version.
Tests included.
