### PR TITLE
Fix issue 57 - errors on VCL reload because of duplicated counters

### DIFF
--- a/test/scrape/6.5.1.json
+++ b/test/scrape/6.5.1.json
@@ -1952,6 +1952,246 @@
       "format": "i",
       "value": 0
     },
+    "VBE.reload_20210114_155148_19902.default.happy": {
+      "description": "Happy health probes",
+      "flag": "b",
+      "format": "b",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.bereq_hdrbytes": {
+      "description": "Request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 6901
+    },
+    "VBE.reload_20210114_155148_19902.default.bereq_bodybytes": {
+      "description": "Request body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.beresp_hdrbytes": {
+      "description": "Response header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 5637
+    },
+    "VBE.reload_20210114_155148_19902.default.beresp_bodybytes": {
+      "description": "Response body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 44
+    },
+    "VBE.reload_20210114_155148_19902.default.pipe_hdrbytes": {
+      "description": "Pipe request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.pipe_out": {
+      "description": "Piped bytes to backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.pipe_in": {
+      "description": "Piped bytes from backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.conn": {
+      "description": "Concurrent connections used",
+      "flag": "g",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.req": {
+      "description": "Backend requests sent",
+      "flag": "c",
+      "format": "i",
+      "value": 27
+    },
+    "VBE.reload_20210114_155148_19902.default.unhealthy": {
+      "description": "Fetches not attempted due to backend being unhealthy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.busy": {
+      "description": "Fetches not attempted due to backend being busy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail": {
+      "description": "Connections failed",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_eacces": {
+      "description": "Connections failed with EACCES or EPERM",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_eaddrnotavail": {
+      "description": "Connections failed with EADDRNOTAVAIL",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_econnrefused": {
+      "description": "Connections failed with ECONNREFUSED",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_enetunreach": {
+      "description": "Connections failed with ENETUNREACH",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_etimedout": {
+      "description": "Connections failed ETIMEDOUT",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.fail_other": {
+      "description": "Connections failed for other reason",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_155148_19902.default.helddown": {
+      "description": "Connection opens not attempted",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.happy": {
+      "description": "Happy health probes",
+      "flag": "b",
+      "format": "b",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.bereq_hdrbytes": {
+      "description": "Request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 6901
+    },
+    "VBE.reload_20210114_160902_21476.default.bereq_bodybytes": {
+      "description": "Request body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.beresp_hdrbytes": {
+      "description": "Response header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 5637
+    },
+    "VBE.reload_20210114_160902_21476.default.beresp_bodybytes": {
+      "description": "Response body bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 44
+    },
+    "VBE.reload_20210114_160902_21476.default.pipe_hdrbytes": {
+      "description": "Pipe request header bytes",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.pipe_out": {
+      "description": "Piped bytes to backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.pipe_in": {
+      "description": "Piped bytes from backend",
+      "flag": "c",
+      "format": "B",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.conn": {
+      "description": "Concurrent connections used",
+      "flag": "g",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.req": {
+      "description": "Backend requests sent",
+      "flag": "c",
+      "format": "i",
+      "value": 27
+    },
+    "VBE.reload_20210114_160902_21476.default.unhealthy": {
+      "description": "Fetches not attempted due to backend being unhealthy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.busy": {
+      "description": "Fetches not attempted due to backend being busy",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail": {
+      "description": "Connections failed",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_eacces": {
+      "description": "Connections failed with EACCES or EPERM",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_eaddrnotavail": {
+      "description": "Connections failed with EADDRNOTAVAIL",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_econnrefused": {
+      "description": "Connections failed with ECONNREFUSED",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_enetunreach": {
+      "description": "Connections failed with ENETUNREACH",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_etimedout": {
+      "description": "Connections failed ETIMEDOUT",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.fail_other": {
+      "description": "Connections failed for other reason",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
+    "VBE.reload_20210114_160902_21476.default.helddown": {
+      "description": "Connection opens not attempted",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    },
     "VBE.boot.default.helddown": {
       "description": "Connection opens not attempted",
       "flag": "c",

--- a/varnish.go
+++ b/varnish.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	vbeReload       = "VBE.reload_"
-	vbeReloadLength = len(vbeReload)
+	vbeReload = "VBE.reload_"
 )
 
 var (
@@ -231,7 +230,7 @@ func findMostRecentVbeReloadPrefix(countersJSON map[string]interface{}) string {
 	for vName, _ := range countersJSON {
 		// Checking only the required ".happy" stat
 		if strings.HasPrefix(vName, vbeReload) && strings.HasSuffix(vName, ".happy") {
-			dotAfterPrefixIndex := vbeReloadLength + strings.Index(vName[vbeReloadLength:], ".")
+			dotAfterPrefixIndex := len(vbeReload) + strings.Index(vName[len(vbeReload):], ".")
 			vbeReloadPrefix := vName[:dotAfterPrefixIndex]
 			if strings.Compare(vbeReloadPrefix, mostRecentVbeReloadPrefix) > 0 {
 				mostRecentVbeReloadPrefix = vbeReloadPrefix


### PR DESCRIPTION
Fixes #57 

**Issue**
The exporter fails when VCL is reloaded.
This happens because Varnish backend counters (VBE) are repeated for each reload with its timestamp:
Example: `VBE.boot.default.happy` and `VBE.reload_20210114_155148_19902.default.happy`
... thus generating duplicated metrics.

The `-p vcl_cooldown=1`  workaround is not good enough, because old counters are still present in varnishstat for some time (granularity is 30s, see https://varnish-cache.org/docs/6.5/reference/varnishd.html#vcl-cooldown).

The result is that on each reload the exporter keeps failing for some time (1m in my tests with `-p vcl_cooldown=1`, 10m without it).

**Solution**
I propose to consider only the counters with the most recent timestamp.
I quickly calculate the most recent timestamp by checking the ".happy" counters, then I filter out the outdated counters.
Should work for any Varnish version.

Tests included:
- unit test for the 2 new methods
- I duplicated VBE metrics in the `6.5.1.json` file with 2 different timestamps to simulate 2 consecutive VCL reloads. Existing tests would fail without the fix.