### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:latest as gobuilder
+
+
+ADD ./* /Workingdir
+WORKDIR /Workingdir
+
+ARG BuildPath=/go/bin/prometheus_varnish_exporter
+
+RUN go build -o $BuildPath
+
+FROM varnish
+
+EXPOSE 9131
+VOLUME /var/lib/varnish
+ENTRYPOINT ["/usr/local/bin/prometheus_varnish_exporter"]
+COPY --from=gobuilder /go/bin/prometheus_varnish_exporter /usr/local/bin


### PR DESCRIPTION
Regarding the Issue #25 i build a Dockerfile for using the prometheus exporter in docker. You just need to mount the Storage "/var/lib/varnish" from your varnish container as Read-Only and you're ready to go.

I would suggest adding a github Action as well, so everytime a new release is deployed, the github action would build a container and put it into the github Registry of this project.


```
version: '2'

services:
  varnish:
    image: varnish
    volumes:
      - varnish_tmpfs:/var/lib/varnish
      - "./default.vcl:/etc/varnish/default.vcl"
    ports:
      - 80:80

  varnishexporter:
    image: prometheus_varnish_exporter:master
    restart: always
    environment:
      VSM_NOPID: 1
    depends_on:
      - varnish
    ports:
      - 9131:9131
    volumes:
      - varnish_tmpfs:/var/lib/varnish/:ro

```