### PR TITLE
fix: include only release files in sha256sum

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,5 +62,5 @@ for goos in linux darwin windows freebsd openbsd netbsd ; do
 done
 
 cd ./bin/release
-shasum --algorithm 256 --binary ./* | sed -En "s/\*\.\/(.*)$/\1/p" > sha256sums.txt
+shasum --algorithm 256 --binary ./prometheus_varnish_exporter* ./dashboards* | sed -En "s/\*\.\/(.*)$/\1/p" > sha256sums.txt
 cd ../..


### PR DESCRIPTION
## Why
SHA256 sums for last release (1.6.1) cannot be verified.
<img width="470" alt="image" src="https://user-images.githubusercontent.com/7701186/217785503-cd9bc555-2532-4956-9204-2de8a5de0b35.png">

The sha256sum.txt also contain a sum for an old sha256sum.txt.
(This is only for 1.6.1, sums for 1.6 do not have this problem).

## Proposed change
Generate sums only for released files

## How to test
```
./build.sh
cd bin/release
sha256sum -c sha256sums.txt
```