### PR TITLE
New optional command-line flag: -e.

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	VersionHash     string
 	VersionDate     string
 
+	ExcludeVBE bool
 	PrometheusExporter = NewPrometheusExporter()
 	VarnishVersion     = NewVarnishVersion()
 	ExitHandler        = &exitHandler{}
@@ -93,11 +94,14 @@ func main() {
 	flag.BoolVar(&StartParams.Test, "test", StartParams.Test, "Test varnishstat availability, prints available metrics and exits.")
 	flag.BoolVar(&StartParams.Raw, "raw", StartParams.Test, "Raw stdout logging without timestamps.")
 	flag.BoolVar(&StartParams.WithGoMetrics, "with-go-metrics", StartParams.WithGoMetrics, "Export go runtime and http handler metrics")
+	excludeVbe := flag.Bool("e", false, "Exclude metrics starting with VBE.")
 
 	// deprecated
 	flag.BoolVar(&StartParams.noExit, "no-exit", StartParams.noExit, "Deprecated: see -exit-on-errors")
 
 	flag.Parse()
+
+	ExcludeVBE = *excludeVbe
 
 	if version {
 		fmt.Printf("%s %s\n", ApplicationName, getVersion(true))

--- a/varnish.go
+++ b/varnish.go
@@ -99,6 +99,9 @@ func ScrapeVarnishFrom(buf []byte, ch chan<- prometheus.Metric) ([]byte, error) 
 		if isOutdatedVbe(vName, mostRecentVbeReloadPrefix) {
 			continue
 		}
+		if ExcludeVBE && strings.HasPrefix(vName, "VBE.") {
+			continue
+		}
 		if vName == "timestamp" {
 			continue
 		}


### PR DESCRIPTION
### Summary

This PR introduces a new optional command-line flag: `-e`.

When this flag is used, the exporter will **exclude all metrics whose names start with `VBE.`**, which commonly correspond to backends from older VCL reloads or temporary states.

### Motivation

In certain setups, `VBE.*` metrics can produce a large number of entries in Prometheus and clutter dashboards or alerting. Being able to disable them can simplify observability and reduce unnecessary metrics load.

### Example

Usage:
```bash
  ./varnish_exporter        # all metrics
  ./varnish_exporter -e     # excludes VBE.* metrics
```